### PR TITLE
Replaces usage of Digest with OpenSSL::Digest

### DIFF
--- a/lib/fog/aws/glacier.rb
+++ b/lib/fog/aws/glacier.rb
@@ -43,7 +43,7 @@ module Fog
           while digests.length > 1
             digests = digests.each_slice(2).map do |pair|
               if pair.length == 2
-                Digest::SHA256.digest(pair[0]+pair[1])
+                OpenSSL::Digest::SHA256.digest(pair[0]+pair[1])
               else
                 pair.first
               end
@@ -65,13 +65,13 @@ module Fog
         def digest_for_part(body)
           chunk_count = [body.bytesize / MEGABYTE + (body.bytesize % MEGABYTE > 0 ? 1 : 0), 1].max
           if body.respond_to? :byteslice
-            digests_for_part = chunk_count.times.map {|chunk_index| Digest::SHA256.digest(body.byteslice(chunk_index * MEGABYTE, MEGABYTE))}
+            digests_for_part = chunk_count.times.map {|chunk_index| OpenSSL::Digest::SHA256.digest(body.byteslice(chunk_index * MEGABYTE, MEGABYTE))}
           else
             if body.respond_to? :encoding
               old_encoding = body.encoding
               body.force_encoding('BINARY')
             end
-            digests_for_part = chunk_count.times.map {|chunk_index| Digest::SHA256.digest(body.slice(chunk_index * MEGABYTE, MEGABYTE))}
+            digests_for_part = chunk_count.times.map {|chunk_index| OpenSSL::Digest::SHA256.digest(body.slice(chunk_index * MEGABYTE, MEGABYTE))}
             if body.respond_to? :encoding
               body.force_encoding(old_encoding)
             end

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -289,7 +289,7 @@ module Fog
         end
 
         def part_headers(chunk, options)
-          md5 = Base64.encode64(Digest::MD5.digest(chunk)).strip
+          md5 = Base64.encode64(OpenSSL::Digest::MD5.digest(chunk)).strip
           encryption_keys = encryption_customer_key_headers.keys
           encryption_headers = options.select { |key| encryption_keys.include?(key) }
           { 'Content-MD5' => md5 }.merge(encryption_headers)
@@ -299,7 +299,7 @@ module Fog
           {
             'x-amz-server-side-encryption-customer-algorithm' => encryption,
             'x-amz-server-side-encryption-customer-key' => Base64.encode64(encryption_key.to_s).chomp!,
-            'x-amz-server-side-encryption-customer-key-md5' => Base64.encode64(Digest::MD5.digest(encryption_key.to_s)).chomp!
+            'x-amz-server-side-encryption-customer-key-md5' => Base64.encode64(OpenSSL::Digest::MD5.digest(encryption_key.to_s)).chomp!
           }
         end
       end

--- a/lib/fog/aws/requests/glacier/create_archive.rb
+++ b/lib/fog/aws/requests/glacier/create_archive.rb
@@ -22,7 +22,7 @@ module Fog
 
           headers = {
             'Content-Length' => body.bytesize.to_s,
-            'x-amz-content-sha256' => Digest::SHA256.hexdigest(body),
+            'x-amz-content-sha256' => OpenSSL::Digest::SHA256.hexdigest(body),
             'x-amz-sha256-tree-hash' => Fog::AWS::Glacier::TreeHash.digest(body)
           }
           headers['x-amz-archive-description'] = Fog::AWS.escape(options['description']) if options['description']

--- a/lib/fog/aws/requests/glacier/upload_part.rb
+++ b/lib/fog/aws/requests/glacier/upload_part.rb
@@ -25,7 +25,7 @@ module Fog
           headers = {
             'Content-Length' => body.bytesize.to_s,
             'Content-Range' => "bytes #{offset}-#{offset+body.bytesize-1}/*",
-            'x-amz-content-sha256' => Digest::SHA256.hexdigest(body),
+            'x-amz-content-sha256' => OpenSSL::Digest::SHA256.hexdigest(body),
             'x-amz-sha256-tree-hash' => hash
           }
 

--- a/lib/fog/aws/requests/sqs/send_message.rb
+++ b/lib/fog/aws/requests/sqs/send_message.rb
@@ -32,7 +32,7 @@ module Fog
 
               now        = Time.now
               message_id = Fog::AWS::Mock.sqs_message_id
-              md5        = Digest::MD5.hexdigest(message)
+              md5        = OpenSSL::Digest::MD5.hexdigest(message)
 
               queue[:messages][message_id] = {
                 'MessageId'  => message_id,

--- a/lib/fog/aws/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/requests/storage/delete_multiple_objects.rb
@@ -47,7 +47,7 @@ module Fog
           data << "</Delete>"
 
           headers['Content-Length'] = data.length
-          headers['Content-MD5'] = Base64.encode64(Digest::MD5.digest(data)).
+          headers['Content-MD5'] = Base64.encode64(OpenSSL::Digest::MD5.digest(data)).
                                    gsub("\n", '')
 
           request({

--- a/lib/fog/aws/requests/storage/post_object_restore.rb
+++ b/lib/fog/aws/requests/storage/post_object_restore.rb
@@ -22,7 +22,7 @@ module Fog
           data = '<RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-3-01"><Days>' + days.to_s + '</Days></RestoreRequest>'
 
           headers = {}
-          headers['Content-MD5'] = Base64.encode64(Digest::MD5.digest(data)).strip
+          headers['Content-MD5'] = Base64.encode64(OpenSSL::Digest::MD5.digest(data)).strip
           headers['Content-Type'] = 'application/xml'
           headers['Date'] = Fog::Time.now.to_date_header
 

--- a/lib/fog/aws/requests/storage/put_bucket_acl.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_acl.rb
@@ -37,7 +37,7 @@ module Fog
             headers['x-amz-acl'] = acl
           end
 
-          headers['Content-MD5'] = Base64.encode64(Digest::MD5.digest(data)).strip
+          headers['Content-MD5'] = Base64.encode64(OpenSSL::Digest::MD5.digest(data)).strip
           headers['Content-Type'] = 'application/json'
           headers['Date'] = Fog::Time.now.to_date_header
 

--- a/lib/fog/aws/requests/storage/put_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_cors.rb
@@ -22,7 +22,7 @@ module Fog
           data = Fog::Storage::AWS.hash_to_cors(cors)
 
           headers = {}
-          headers['Content-MD5'] = Base64.encode64(Digest::MD5.digest(data)).strip
+          headers['Content-MD5'] = Base64.encode64(OpenSSL::Digest::MD5.digest(data)).strip
           headers['Content-Type'] = 'application/json'
           headers['Date'] = Fog::Time.now.to_date_header
 

--- a/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
@@ -86,7 +86,7 @@ module Fog
           request({
                     :body     => body,
                     :expects  => 200,
-                    :headers  => {'Content-MD5' => Base64.encode64(Digest::MD5.digest(body)).chomp!,
+                    :headers  => {'Content-MD5' => Base64.encode64(OpenSSL::Digest::MD5.digest(body)).chomp!,
                       'Content-Type' => 'application/xml'},
                     :bucket_name => bucket_name,
                     :method   => 'PUT',

--- a/lib/fog/aws/requests/storage/put_bucket_notification.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_notification.rb
@@ -54,7 +54,7 @@ module Fog
           request({
             :body     => body,
             :expects  => 200,
-            :headers  => {'Content-MD5' => Base64.encode64(Digest::MD5.digest(body)).chomp!,
+            :headers  => {'Content-MD5' => Base64.encode64(OpenSSL::Digest::MD5.digest(body)).chomp!,
               'Content-Type' => 'application/xml'},
             :bucket_name => bucket_name,
             :method   => 'PUT',

--- a/lib/fog/aws/requests/storage/put_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_tagging.rb
@@ -27,7 +27,7 @@ DATA
           request({
             :body     => data,
             :expects  => 204,
-            :headers  => {'Content-MD5' => Base64.encode64(Digest::MD5.digest(data)).chomp!, 'Content-Type' => 'application/xml'},
+            :headers  => {'Content-MD5' => Base64.encode64(OpenSSL::Digest::MD5.digest(data)).chomp!, 'Content-Type' => 'application/xml'},
             :bucket_name => bucket_name,
             :method   => 'PUT',
             :query    => {'tagging' => nil}

--- a/lib/fog/aws/requests/storage/put_object_acl.rb
+++ b/lib/fog/aws/requests/storage/put_object_acl.rb
@@ -45,7 +45,7 @@ module Fog
             headers['x-amz-acl'] = acl
           end
 
-          headers['Content-MD5'] = Base64.encode64(Digest::MD5.digest(data)).strip
+          headers['Content-MD5'] = Base64.encode64(OpenSSL::Digest::MD5.digest(data)).strip
           headers['Content-Type'] = 'application/json'
           headers['Date'] = Fog::Time.now.to_date_header
 

--- a/lib/fog/aws/requests/storage/shared_mock_methods.rb
+++ b/lib/fog/aws/requests/storage/shared_mock_methods.rb
@@ -50,7 +50,7 @@ module Fog
           object = {
             :body             => body,
             'Content-Type'    => options['Content-Type'],
-            'ETag'            => Digest::MD5.hexdigest(body),
+            'ETag'            => OpenSSL::Digest::MD5.hexdigest(body),
             'Key'             => object_name,
             'Last-Modified'   => Fog::Time.now.to_date_header,
             'Content-Length'  => options['Content-Length'],

--- a/lib/fog/aws/signaturev4.rb
+++ b/lib/fog/aws/signaturev4.rb
@@ -40,7 +40,7 @@ module Fog
 #{canonical_query_string(params[:query])}
 #{canonical_headers(params[:headers])}
 #{signed_headers(params[:headers])}
-#{body_sha || Digest::SHA256.hexdigest(params[:body] || '')}
+#{body_sha || OpenSSL::Digest::SHA256.hexdigest(params[:body] || '')}
 DATA
         canonical_request.chop!
 
@@ -48,7 +48,7 @@ DATA
 #{ALGORITHM}
 #{date.to_iso8601_basic}
 #{credential_scope(date)}
-#{Digest::SHA256.hexdigest(canonical_request)}
+#{OpenSSL::Digest::SHA256.hexdigest(canonical_request)}
 DATA
 
         string_to_sign.chop!

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -585,7 +585,7 @@ module Fog
               params[:headers]['x-amz-content-sha256'] = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD'
               params[:headers]['x-amz-decoded-content-length'] = params[:headers].delete 'Content-Length'
             else
-              params[:headers]['x-amz-content-sha256'] ||= Digest::SHA256.hexdigest(params[:body] || '')
+              params[:headers]['x-amz-content-sha256'] ||= OpenSSL::Digest::SHA256.hexdigest(params[:body] || '')
             end
             signature_components = @signer.signature_components(params, date, params[:headers]['x-amz-content-sha256'])
             params[:headers]['Authorization'] = @signer.components_to_header(signature_components)
@@ -692,8 +692,8 @@ AWS4-HMAC-SHA256-PAYLOAD
 #{date.to_iso8601_basic}
 #{signer.credential_scope(date)}
 #{previous_signature}
-#{Digest::SHA256.hexdigest('')}
-#{Digest::SHA256.hexdigest(data)}
+#{OpenSSL::Digest::SHA256.hexdigest('')}
+#{OpenSSL::Digest::SHA256.hexdigest(data)}
 DATA
             hmac = signer.derived_hmac(date)
             hmac.sign(string_to_sign.strip).unpack('H*').first

--- a/tests/models/storage/file_tests.rb
+++ b/tests/models/storage/file_tests.rb
@@ -99,7 +99,7 @@ Shindo.tests("Storage[:aws] | file", ["aws"]) do
       @directory.files.get('multipart-encrypted-upload',
         'x-amz-server-side-encryption-customer-algorithm' => 'AES256',
         'x-amz-server-side-encryption-customer-key' => Base64.encode64(encryption_key).chomp!,
-        'x-amz-server-side-encryption-customer-key-MD5' => Base64.encode64(Digest::MD5.digest(encryption_key.to_s)).chomp!
+        'x-amz-server-side-encryption-customer-key-MD5' => Base64.encode64(OpenSSL::Digest::MD5.digest(encryption_key.to_s)).chomp!
       ).body == "x" * 6*1024**2
     end
 

--- a/tests/requests/glacier/tree_hash_tests.rb
+++ b/tests/requests/glacier/tree_hash_tests.rb
@@ -1,27 +1,27 @@
 Shindo.tests('AWS::Glacier | glacier tree hash calcuation', ['aws']) do
 
   tests('tree_hash(single part < 1MB)') do
-    returns(Digest::SHA256.hexdigest('')) { Fog::AWS::Glacier::TreeHash.digest('')}
+    returns(OpenSSL::Digest::SHA256.hexdigest('')) { Fog::AWS::Glacier::TreeHash.digest('')}
   end
 
   tests('tree_hash(multibyte characters)') do
     body = ("\xC2\xA1" * 1024*1024)
     body.force_encoding('UTF-8') if body.respond_to? :encoding
 
-    expected = Digest::SHA256.hexdigest(
-                Digest::SHA256.digest("\xC2\xA1" * 1024*512) + Digest::SHA256.digest("\xC2\xA1" * 1024*512)
+    expected = OpenSSL::Digest::SHA256.hexdigest(
+                OpenSSL::Digest::SHA256.digest("\xC2\xA1" * 1024*512) + OpenSSL::Digest::SHA256.digest("\xC2\xA1" * 1024*512)
               )
     returns(expected) { Fog::AWS::Glacier::TreeHash.digest(body)}
   end
 
   tests('tree_hash(power of 2 number of parts)') do
     body = ('x' * 1024*1024) + ('y'*1024*1024) + ('z'*1024*1024) + ('t'*1024*1024)
-    expected = Digest::SHA256.hexdigest(
-                 Digest::SHA256.digest(
-                    Digest::SHA256.digest('x' * 1024*1024) + Digest::SHA256.digest('y' * 1024*1024)
+    expected = OpenSSL::Digest::SHA256.hexdigest(
+                 OpenSSL::Digest::SHA256.digest(
+                    OpenSSL::Digest::SHA256.digest('x' * 1024*1024) + OpenSSL::Digest::SHA256.digest('y' * 1024*1024)
                  ) +
-                 Digest::SHA256.digest(
-                   Digest::SHA256.digest('z' * 1024*1024) + Digest::SHA256.digest('t' * 1024*1024)
+                 OpenSSL::Digest::SHA256.digest(
+                   OpenSSL::Digest::SHA256.digest('z' * 1024*1024) + OpenSSL::Digest::SHA256.digest('t' * 1024*1024)
                  )
                )
 
@@ -30,11 +30,11 @@ Shindo.tests('AWS::Glacier | glacier tree hash calcuation', ['aws']) do
 
   tests('tree_hash(non power of 2 number of parts)') do
     body = ('x' * 1024*1024) + ('y'*1024*1024) + ('z'*1024*1024)
-    expected = Digest::SHA256.hexdigest(
-                 Digest::SHA256.digest(
-                    Digest::SHA256.digest('x' * 1024*1024) + Digest::SHA256.digest('y' * 1024*1024)
+    expected = OpenSSL::Digest::SHA256.hexdigest(
+                 OpenSSL::Digest::SHA256.digest(
+                    OpenSSL::Digest::SHA256.digest('x' * 1024*1024) + OpenSSL::Digest::SHA256.digest('y' * 1024*1024)
                  ) +
-                 Digest::SHA256.digest('z' * 1024*1024)
+                 OpenSSL::Digest::SHA256.digest('z' * 1024*1024)
                )
 
     returns(expected) { Fog::AWS::Glacier::TreeHash.digest(body)}
@@ -47,12 +47,12 @@ Shindo.tests('AWS::Glacier | glacier tree hash calcuation', ['aws']) do
 
     tree_hash.add_part('z'* 1024*1024 + 't'*1024*1024)
 
-    expected = Digest::SHA256.hexdigest(
-                 Digest::SHA256.digest(
-                    Digest::SHA256.digest('x' * 1024*1024) + Digest::SHA256.digest('y' * 1024*1024)
+    expected = OpenSSL::Digest::SHA256.hexdigest(
+                 OpenSSL::Digest::SHA256.digest(
+                    OpenSSL::Digest::SHA256.digest('x' * 1024*1024) + OpenSSL::Digest::SHA256.digest('y' * 1024*1024)
                  ) +
-                 Digest::SHA256.digest(
-                   Digest::SHA256.digest('z' * 1024*1024) + Digest::SHA256.digest('t' * 1024*1024)
+                 OpenSSL::Digest::SHA256.digest(
+                   OpenSSL::Digest::SHA256.digest('z' * 1024*1024) + OpenSSL::Digest::SHA256.digest('t' * 1024*1024)
                  )
                )
     returns(expected) { tree_hash.hexdigest}


### PR DESCRIPTION
The Digest class has some thread safety issues and gives runtime error 
Digest::Base cannot be directly inherited in Ruby #261

ruby/ruby@c02fa39
aws/aws-sdk-ruby#525
aws/aws-sdk-ruby#529
